### PR TITLE
Update setup-node action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           crate: cargo-sort
           version: "1.0"
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: install foundry


### PR DESCRIPTION
Updated actions/setup-node from v3 to v4 in .github/workflows/main.yml to stay current with the latest version.
Proof:
v4 Release Notes-https://github.com/actions/setup-node/releases/tag/v4.4.0