### PR TITLE
GitHub Actions workflow to use Node.js 24 instead of 18.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           version: "1.0"
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
       - name: install foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of 18.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)